### PR TITLE
Add homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,16 @@ A Persian (Farsi) Font
 
 ## Install
 
+#### Download
 Grab the [latest release](https://github.com/rastikerdar/vazir-font/releases/latest) file.
 
-Or you can get it on bower:
-
+#### Bower
 ```
 bower install vazir-font --save
 ```
 
-Or [RawGit](https://rawgit.com) CDN:
+#### CDN
+Link fonts from the [RawGit](https://rawgit.com) CDN:
 
 ```html
 <link href="https://cdn.rawgit.com/rastikerdar/vazir-font/v[X.Y.Z]/dist/font-face.css" rel="stylesheet" type="text/css" />
@@ -75,3 +76,10 @@ Replace [X.Y.Z] with the latest version (e.g. 6.3.3) and integrate the font into
 font-family: 'Vazir', sans-serif;
 ```
 
+#### Homebrew
+You can install the font on macOS machines by tapping the caskroom/fonts repo:  
+
+```shell
+brew tap caskroom/fonts
+brew install font-vazir
+```


### PR DESCRIPTION
Caskroom's fonts tap [has the latest version](https://github.com/caskroom/homebrew-fonts/pull/929) of Vazir. Why not adding the instructions here?