### PR TITLE
Auto-publish to npm after each release using GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Hi,

This GitHub workflow allows auto publishing new releases to npm. So far I've been doing this manually after each release, which sometimes causes delays.

After committing this workflow, a new secret should be added to the repo for npm publishing.

@rastikerdar  I can either transfer the ownership of npm package to you, then you can generate an Auth Token on npm and add that to the repo or I can somehow send you the Auth Token for my account to be added to the repo. Please let me know.

Thanks